### PR TITLE
Add basic Dashboard test

### DIFF
--- a/src/views/__tests__/Dashboard.test.js
+++ b/src/views/__tests__/Dashboard.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import Dashboard from '../Dashboard';
+
+describe('Dashboard view', () => {
+  test('shows the Total Shipments information', () => {
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    // "Total Shipments" text appears more than once on the page
+    const shipments = screen.getAllByText(/Total Shipments/i);
+    expect(shipments.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add test for Dashboard view
- rename test per inline feedback

## Testing
- `npm test --silent > /tmp/test.log 2>&1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5d45581c8332bdca8800f3bda370